### PR TITLE
can now generate boilerplate with either IDs, Classes, or both.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,5 +1,7 @@
 'use babel';
 
+var mode = 0 //0: ids and classes, 1: classes, 2: ids
+
 function applyWhitespace(str) {
   return str.replace(/\\n/g, "\n").replace(/\\t/g, "\t");
 }
@@ -9,18 +11,25 @@ function saveElement(css, el) {
   const RULELIST_CLOSE = applyWhitespace(atom.config.get('html-to-css.rulelist-close'));
   const GROUPING_CHAR = applyWhitespace(atom.config.get('html-to-css.grouping-character'));
 
-  css = css + `.${el.name}${RULELIST_OPEN}`;
-  if (el.children && el.children.length) {
-    el.children.map((ch) => {
-      const name = ch.name.replace(el.name, GROUPING_CHAR);
-      css = css + `\t${name}${RULELIST_OPEN}\t${RULELIST_CLOSE}`;
-    });
+  if(el.type === 'id' && mode !== 1){
+    css = css + `#${el.name}${RULELIST_OPEN}`;
+  }else if(el.type === 'class' && mode !== 2){
+    css = css + `.${el.name}${RULELIST_OPEN}`;
+    if (el.children && el.children.length) {
+      el.children.map((ch) => {
+        const name = ch.name.replace(el.name, GROUPING_CHAR);
+        css = css + `\t${name}${RULELIST_OPEN}\t${RULELIST_CLOSE}`;
+      });
+    }
+  }else{
+    return css;
   }
   css = css + RULELIST_CLOSE;
   return css;
 }
 
-exports.format = function(json) {
+exports.format = function(json, setMode) {
+  mode = setMode;
   const css = "";
   return json.reduce(saveElement, css);
 }

--- a/lib/html-to-css.js
+++ b/lib/html-to-css.js
@@ -47,8 +47,15 @@ export default {
   activate(state) {
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.commands.add('atom-workspace', {
+      'html-to-css:generateClasses': () => this.generateClasses()
+    }));
+    this.subscriptions.add(atom.commands.add('atom-workspace', {
+      'html-to-css:generateIDs': () => this.generateIDs()
+    }));
+    this.subscriptions.add(atom.commands.add('atom-workspace', {
       'html-to-css:generate': () => this.generate()
     }));
+
   },
 
   deactivate() {
@@ -58,7 +65,7 @@ export default {
   serialize() {
   },
 
-  generate() {
+  generate(mode = 0) {
     const pane = atom.workspace.getActivePane();
     const editor = pane.getActiveEditor();
     const text = editor.getSelectedText();
@@ -67,12 +74,23 @@ export default {
     if (atom.config.get('html-to-css.bem-group')) {
       preparedJson = group(preparedJson);
     }
-    const css = format(preparedJson);
+    const css = format(preparedJson, mode);
     if (css) {
       atom.clipboard.write(css);
       atom.notifications.addSuccess('CSS boilerplate copied to clipboard.');
+      return true;
     } else {
       atom.notifications.addError('Parsing failed');
+      if(text === "") atom.notifications.addError('No Selected Text.');
+      return false;
     }
+  },
+
+  generateClasses(){
+    if(this.generate(1)) atom.notifications.addSuccess('IDs excluded.');
+  },
+
+  generateIDs(){
+    if(this.generate(2)) atom.notifications.addSuccess('Classes excluded.');
   }
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -10,9 +10,10 @@ function splitClasses(classNames) {
   return classNames.split(" ");
 }
 
-function storeElement(store, className) {
+function storeElement(store, selectorType, selector) {
   const ret = {
-    name: className,
+    name: selector,
+    type: selectorType,
     children: []
   };
   if (!store.find((el) => el.name === ret.name)) store.push(ret);
@@ -22,8 +23,13 @@ function parseNode(store, node) {
     if (node.type !== 'tag') return;
     if (node.attribs.class || node.attribs.classname) {
       const classes = splitClasses(node.attribs.class || node.attribs.classname);
-      classes.map(partial(storeElement, store));
+      classes.map(partial(storeElement, store, 'class'));
     }
+
+    if (node.attribs.id) {
+      storeElement(store,'id', node.attribs.id);
+    }
+
     if (node.children.length) {
       return parseArray(node.children, store);
     } else {

--- a/menus/html-to-css.json
+++ b/menus/html-to-css.json
@@ -2,8 +2,16 @@
   "context-menu": {
     "atom-text-editor": [
       {
-        "label": "HTML-to-CSS: Generate",
+        "label": "HTML-to-CSS: Generate (IDs and Classes)",
         "command": "html-to-css:generate"
+      },
+      {
+        "label": "HTML-to-CSS: Generate (Classes Only)",
+        "command": "html-to-css:generateClasses"
+      },
+      {
+        "label": "HTML-to-CSS: Generate (IDs Only)",
+        "command": "html-to-css:generateIDs"
       }
     ]
   },
@@ -15,8 +23,16 @@
           "label": "html-to-css",
           "submenu": [
             {
-              "label": "Generate",
+              "label": "Generate (IDs and Classes)",
               "command": "html-to-css:generate"
+            },
+            {
+              "label": "Generate (Classes Only)",
+              "command": "html-to-css:generateClasses"
+            },
+            {
+              "label": "Generate (IDs Only)",
+              "command": "html-to-css:generateIDs"
             }
           ]
         }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
   ],
   "author": "Szymon Pilkowski <szymon.pilkowski@gmail.com>",
   "activationCommands": {
-    "atom-workspace": "html-to-css:generate"
-  },
+    "atom-workspace": [
+      "html-to-css:generate",
+      "html-to-css:generateClasses",
+      "html-to-css:generateIDs"
+  ]},
   "repository": "https://github.com/ardcore/atom-html-to-css",
   "license": "MIT",
   "engines": {
@@ -20,6 +23,7 @@
   },
   "dependencies": {
     "htmlparser2": "^3.9.0",
-    "partial-any": "0.0.2"
+    "partial-any": "0.0.2",
+    "stringy": "^0.1.0"
   }
 }


### PR DESCRIPTION
I'm working on a project that requires I generate CSS for about 100 ids per page. Your package was the closest thing I could find that could automate the process, so I added the ability to choose to generate a boilerplate for Classed and IDS, Just Classes, or Just IDs. 

I'm relatively new to JS, and an absolute beginner at atom package development, so please let me know if there's anything I could've done better.